### PR TITLE
[22] Rename name of event for more consistent semantics

### DIFF
--- a/include/scl/simulation/event.h
+++ b/include/scl/simulation/event.h
@@ -67,9 +67,9 @@ enum class EventType {
   SEND,
 
   /**
-   * @brief Event generated when data is received on a channel.
+   * @brief Event generated when data is read from a channel.
    */
-  RECV,
+  READ,
 
   /**
    * @brief Event generated when a channel is queried for the presence of data.
@@ -146,12 +146,12 @@ struct Event {
                                          std::size_t amount);
 
   /**
-   * @brief Create an event indicating that some data was received on a channel.
-   * @param timestamp the time the data was received.
+   * @brief Create an event indicating that some data was read from a channel.
+   * @param timestamp the time the data was read.
    * @param channel_id the ID of the channel.
-   * @param amount the amount of bytes received.
+   * @param amount the amount of bytes read.
    */
-  static std::shared_ptr<Event> recvData(util::Time::Duration timestamp,
+  static std::shared_ptr<Event> readData(util::Time::Duration timestamp,
                                          ChannelId channel_id,
                                          std::size_t amount);
 

--- a/src/scl/simulation/channel.cc
+++ b/src/scl/simulation/channel.cc
@@ -79,7 +79,7 @@ coro::Task<net::Packet> sim::details::SimulatedChannel::recv() {
   elapsed = m_context.recv(m_cid.remote, totalPacketSize(packet), elapsed);
 
   const std::size_t nbytes = totalPacketSize(packet);
-  m_context.recordEvent(Event::recvData(elapsed, m_cid, nbytes));
+  m_context.recordEvent(Event::readData(elapsed, m_cid, nbytes));
   m_context.startClock();
   co_return packet;
 }

--- a/src/scl/simulation/event.cc
+++ b/src/scl/simulation/event.cc
@@ -61,10 +61,10 @@ std::shared_ptr<sim::Event> sim::Event::sendData(util::Time::Duration timestamp,
                                             amount);
 }
 
-std::shared_ptr<sim::Event> sim::Event::recvData(util::Time::Duration timestamp,
+std::shared_ptr<sim::Event> sim::Event::readData(util::Time::Duration timestamp,
                                                  sim::ChannelId channel_id,
                                                  std::size_t amount) {
-  return std::make_shared<ChannelDataEvent>(EventType::RECV,
+  return std::make_shared<ChannelDataEvent>(EventType::READ,
                                             timestamp,
                                             channel_id,
                                             amount);
@@ -118,8 +118,8 @@ std::string eventTypeToString(sim::EventType type) {
     case sim::EventType::SEND:
       return "SEND";
       break;
-    case sim::EventType::RECV:
-      return "RECV";
+    case sim::EventType::READ:
+      return "READ";
       break;
     case sim::EventType::HAS_DATA:
       return "HAS_DATA";
@@ -263,7 +263,7 @@ std::ostream& sim::operator<<(std::ostream& stream, const sim::Event* event) {
       break;
 
     case EventType::SEND:
-    case EventType::RECV:
+    case EventType::READ:
       writeEvent(stream, dynamic_cast<const ChannelDataEvent*>(event));
       break;
 

--- a/test/scl/simulation/test_channel.cc
+++ b/test/scl/simulation/test_channel.cc
@@ -81,7 +81,7 @@ TEST_CASE("SimulatedChannel send/recv", "[sim]") {
   REQUIRE(pr.read<int>() == 3);
 
   REQUIRE(gctx.traces[1].size() == 2);
-  REQUIRE(gctx.traces[1].back()->type == sim::EventType::RECV);
+  REQUIRE(gctx.traces[1].back()->type == sim::EventType::READ);
   REQUIRE(getChannelDataEventAmount(gctx.traces[1].back()) == expected_size);
 
   REQUIRE(gctx.sends[{0, 1}].empty());

--- a/test/scl/simulation/test_event.cc
+++ b/test/scl/simulation/test_event.cc
@@ -102,11 +102,11 @@ TEST_CASE("Simulation events", "[sim]") {
   }
 
   SECTION("RECV") {
-    auto e = sim::Event::recvData(123ms, {1, 2}, 10);
+    auto e = sim::Event::readData(123ms, {1, 2}, 10);
     REQUIRE(str(e) ==
             "{"
             "\"timestamp\":123,"
-            "\"type\":\"RECV\","
+            "\"type\":\"READ\","
             "\"metadata\":{"
             "\"channel_id\":{\"local\":1,\"remote\":2},"
             "\"amount\":10"

--- a/test/scl/simulation/test_simulator.cc
+++ b/test/scl/simulation/test_simulator.cc
@@ -99,7 +99,7 @@ TEST_CASE("Simulate SendRecv protocol", "[sim]") {
       REQUIRE(trace[0]->type == sim::EventType::START);
       REQUIRE(trace[1]->type == sim::EventType::PROTOCOL_BEGIN);
       REQUIRE(trace[2]->type == sim::EventType::SEND);
-      REQUIRE(trace[3]->type == sim::EventType::RECV);
+      REQUIRE(trace[3]->type == sim::EventType::READ);
       REQUIRE(trace[4]->type == sim::EventType::CLOSE);
       REQUIRE(trace[5]->type == sim::EventType::CLOSE);
       REQUIRE(trace[6]->type == sim::EventType::PROTOCOL_END);


### PR DESCRIPTION
Renames the `sim::EventType::RECV` event to `sim::EventType::READ` to more clearly signal that the event is created only when data is read from a channel, not when it is received.